### PR TITLE
Set up GitHub actions and required code to build the package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: build
+
+on: [push]
+
+jobs:
+  build:
+      runs-on: ${{ matrix.os }}
+
+      strategy:
+        matrix:
+          os: [ubuntu-latest, macos-latest, windows-latest]
+
+      env:
+        OS: ${{ matrix.os }}
+        PYTHON: '3.8'
+
+      steps:
+
+        - uses: actions/checkout@v1
+
+        - name: Set up Python
+          uses: actions/setup-python@master
+          with:
+            python-version: 3.8
+
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+
+        - name: Test and generate coverage report
+          run: |
+            pip install pytest
+            pip install pytest-cov
+            pytest --cov=./ --cov-report=xml
+
+        - name: Upload coverage to Codecov
+          uses: codecov/codecov-action@v1
+          with:
+            file: ./coverage.xml
+            fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,147 @@
-.DS_Store
+# virtual environment
+venv/*
+
+# package specific
 *.swp
 input/*
 output/*
 validation/*
 dask-worker-space/*
 __pycache__
+
+# package for develop build
+wolfgang.egg-info
+
+# PyCharm
+.idea/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.DS_Store
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
 .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![build](https://github.com/IMMM-SFA/wolfgang/workflows/build/badge.svg) [![codecov](https://codecov.io/gh/IMMM-SFA/wolfgang/branch/actions/graph/badge.svg?token=IPOY8984MB)](https://codecov.io/gh/IMMM-SFA/wolfgang) 
+
+
 ### Wolfgang Mosart-WM
 
 Wolfgang is a python translation of Mosart-WM, a model for water routing and reservoir management written in Fortran. The original code can be found at [IWMM](https://github.com/IMMM-SFA/iwmm) and [E3SM](https://github.com/E3SM-Project/E3SM), in which Mosart is the hdyrological component of a larger suite of earth-science models. The motivation for rewriting is largely for developer convenience -- running, debugging, and adding new capabilities were becoming increasingly difficult due to the complexity of the codebase and lack of familiarity with Fortran. This version aims to be intuitive, lightweight, and well documented, while still being highly interoperable.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![build](https://github.com/IMMM-SFA/wolfgang/workflows/build/badge.svg) [![codecov](https://codecov.io/gh/IMMM-SFA/wolfgang/branch/actions/graph/badge.svg?token=IPOY8984MB)](https://codecov.io/gh/IMMM-SFA/wolfgang) 
+![build](https://github.com/IMMM-SFA/wolfgang/workflows/build/badge.svg) [![codecov](https://codecov.io/gh/IMMM-SFA/wolfgang/branch/main/graph/badge.svg?token=IPOY8984MB)](https://codecov.io/gh/IMMM-SFA/wolfgang)
 
 
 ### Wolfgang Mosart-WM

--- a/mosart/__init__.py
+++ b/mosart/__init__.py
@@ -1,4 +1,0 @@
-# expose the Mosart class at the package level
-from mosart.mosart import Mosart
-
-__all__ = ['Mosart']

--- a/mosart/__init__.py
+++ b/mosart/__init__.py
@@ -1,2 +1,4 @@
 # expose the Mosart class at the package level
 from mosart.mosart import Mosart
+
+__all__ = ['Mosart']

--- a/mosart/__init__.py
+++ b/mosart/__init__.py
@@ -1,0 +1,2 @@
+# expose the Mosart class at the package level
+from mosart.mosart import Mosart

--- a/mosart/tests/test_example.py
+++ b/mosart/tests/test_example.py
@@ -1,0 +1,14 @@
+import unittest
+
+
+class TestExample(unittest.TestCase):
+    """Sample test case to be deleted."""
+
+    def test_something(self):
+
+        # make test pass
+        self.assertEqual(True, True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 bmipy==2.0
-nc-time-axis=1.2.0
+nc-time-axis==1.2.0
 epiweeks==2.1.2
 fastparquet==0.4.1
-matplotlib==3.3.
+matplotlib==3.3.3
 netCDF4==1.5.4
 pandas==1.1.4
 pathvalidate==2.3.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+from setuptools import setup, find_packages
+
+
+def readme():
+    """Return the contents of the project README file."""
+    with open('README.md') as f:
+        return f.read()
+
+
+def get_requirements():
+    """Return a list of package requirements from the requirements.txt file."""
+    with open('requirements.txt') as f:
+        return f.read().split()
+
+
+setup(
+    name='wolfgang',
+    version='0.1.0',
+    packages=find_packages(),
+    url='https://github.com/IMMM-SFA/wolfgang',
+    license='BSD2',
+    author='Travis Thurber',
+    author_email='thurber',
+    description='Python implementation of MOSART-WM:  A water routing and management model',
+    long_description=readme(),
+    python_requires='>=3.6.*, <4',
+    install_requires=get_requirements()
+)


### PR DESCRIPTION
**Purpose**:
Set up GitHub actions to build the package, run tests, and report code coverage on `push` for any branch.

**Topics Addressed**:
- Set up a sample test that may be removed upon test suite expansion.  This test is located in the `mosart/tests` level of the package
- Set up a GitHub actions workflow that runs tests in the test directory using Python 3.8 on the latest images for Ubuntu, Mac OSX and Windows
- Linked results from the tests to Codecov
- Added badges reported test outcomes in the root README
- Added required code to build the package
- Made the `.gitignore` file more robust
- Fixed bug in requirements file

**NOTICE**:
The current branch set up in Codecov as the target is `actions`.   This needs to be changed to `main` once this branch has been merged.